### PR TITLE
feat: rotas privadas funcionando

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lucide-react": "^0.503.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.5.3",
+        "react-router-dom": "^7.6.1",
         "shadcn": "^2.5.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.4"
@@ -5074,14 +5074,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.3.tgz",
-      "integrity": "sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.1.tgz",
+      "integrity": "sha512-hPJXXxHJZEsPFNVbtATH7+MMX43UDeOauz+EAU4cgqTn7ojdI9qQORqS8Z0qmDlL1TclO/6jLRYUEtbWidtdHQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5097,12 +5096,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.3.tgz",
-      "integrity": "sha512-cK0jSaTyW4jV9SRKAItMIQfWZ/D6WEZafgHuuCb9g+SjhLolY78qc+De4w/Cz9ybjvLzShAmaIMEXt8iF1Cm+A==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.1.tgz",
+      "integrity": "sha512-vxU7ei//UfPYQ3iZvHuO1D/5fX3/JOqhNTbRR+WjSBWxf9bIvpWK+ftjmdfJHzPOuMQKe2fiEdG+dZX6E8uUpA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.5.3"
+        "react-router": "7.6.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5688,12 +5687,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/tw-animate-css": {
       "version": "1.2.9",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lucide-react": "^0.503.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.5.3",
+    "react-router-dom": "^7.6.1",
     "shadcn": "^2.5.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,5 @@
-import "./App.css";
-import { ProfileRestaurant } from "./features/system-adm/pages/profile-restaurant";
+import { Router } from './router/router';
 
-
-
-function App() {
-  return (
-    <ProfileRestaurant/>
-  )
+export function App() {
+  return <Router />;
 }
-
-export default App;

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  login: (token: string) => void;
+  logout: () => void;
+  isAuthenticated: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const savedToken = localStorage.getItem('token');
+    if (savedToken) {
+      setToken(savedToken);
+    }
+  }, []);
+
+  const login = (newToken: string) => {
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout, isAuthenticated: !!token }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth deve ser usado dentro de AuthProvider');
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,15 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+// src/main.tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import './index.css';
+import { AuthProvider } from './contexts/auth-context';
+import { App } from './App';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </StrictMode>
+);

--- a/src/router/private-router.tsx
+++ b/src/router/private-router.tsx
@@ -1,0 +1,13 @@
+import { useAuth } from '@/contexts/auth-context';
+import { JSX } from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  children: JSX.Element;
+}
+
+export function PrivateRoute({ children }: PrivateRouteProps) {
+  const { isAuthenticated } = useAuth();
+
+  return isAuthenticated ? children : <Navigate to="/" replace />;
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,8 +1,11 @@
+// src/routes/Router.tsx
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { LoginAdm } from '../features/system-adm/pages/login-adm';
 import { RegisterAdm } from '../features/system-adm/pages/register-adm';
 import { ProfileRestaurant } from '@/features/system-adm/pages/profile-restaurant';
 import { Orders } from '@/features/system-adm/pages/orders';
+import { PrivateRoute } from './private-router';
+
 
 export function Router() {
   return (
@@ -10,9 +13,23 @@ export function Router() {
       <Routes>
         <Route path="/" element={<LoginAdm />} />
         <Route path="/register" element={<RegisterAdm />} />
-        <Route path="/profile-restaurante" element={<ProfileRestaurant />} />
-        <Route path="/orders" element={<Orders/> } />
-        
+
+        <Route
+          path="/profile-restaurante"
+          element={
+            <PrivateRoute>
+              <ProfileRestaurant />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/orders"
+          element={
+            <PrivateRoute>
+              <Orders />
+            </PrivateRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
feat: rotas privadas funcionando

### ✨ O que foi feito

- Criadas rotas privadas usando o `PrivateRoute`
- Token de autenticação agora é compartilhado via `AuthContext`
- Evita acesso direto ao `localStorage` nas páginas
- Roteamento ajustado para proteger páginas sensíveis (ex: /orders, /profile-restaurante)

### 📁 Arquivos modificados

- `src/routes/Router.tsx`
- `src/routes/PrivateRoute.tsx`
- `src/contexts/AuthContext.tsx`
-  'src/App.tsx'

### ✅ Como testar

1. Faça login na página `/`
2. Verifique se o token foi salvo e rotas como `/orders` e `/profile-restaurante` estão acessíveis
3. Tente acessar essas rotas sem token → deve redirecionar para `/`

### 🔐 Observação

O token é carregado do localStorage uma vez e gerenciado pelo `AuthContext`, permitindo acesso centralizado e mais seguro nas páginas protegidas.
