### PR TITLE
fix: correção do bug de refresh

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -5,18 +5,21 @@ interface AuthContextType {
   login: (token: string) => void;
   logout: () => void;
   isAuthenticated: boolean;
+  isLoading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const savedToken = localStorage.getItem('token');
     if (savedToken) {
       setToken(savedToken);
     }
+    setIsLoading(false); 
   }, []);
 
   const login = (newToken: string) => {
@@ -30,7 +33,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, login, logout, isAuthenticated: !!token }}>
+    <AuthContext.Provider
+      value={{
+        token,
+        login,
+        logout,
+        isAuthenticated: !!token,
+        isLoading,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/router/private-router.tsx
+++ b/src/router/private-router.tsx
@@ -7,7 +7,11 @@ interface PrivateRouteProps {
 }
 
 export function PrivateRoute({ children }: PrivateRouteProps) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <div>Carregando...</div>; // Pode trocar por um Spinner se quiser
+  }
 
   return isAuthenticated ? children : <Navigate to="/" replace />;
 }


### PR DESCRIPTION
Corrige o comportamento onde o usuário era redirecionado para a tela de login ao recarregar a página.
Agora, o token é carregado do localStorage no início da aplicação e a rota protegida espera esse carregamento antes de decidir se redireciona.

Alterações principais:

Adição de isLoading no AuthContext.

Ajuste no PrivateRoute para aguardar o carregamento do token.